### PR TITLE
Fix for issue#30 - Improve initialization of randomizer

### DIFF
--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/streams/ClusteringSourceProcessor.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/streams/ClusteringSourceProcessor.java
@@ -54,7 +54,7 @@ public final class ClusteringSourceProcessor implements Processor {
 	private StreamSource streamSource;
 	private Instance firstInstance;
 	private boolean isInited = false;
-        private Random random; 
+	private Random random = new Random(); 
 	private int id;
 	private double samplingThreshold;
         
@@ -68,7 +68,6 @@ public final class ClusteringSourceProcessor implements Processor {
 	@Override
 	public void onCreate(int id) {
 		this.id = id;
-                this.random = new Random();
 		logger.debug("Creating ClusteringSourceProcessor with id {}", this.id);
 	}
 


### PR DESCRIPTION
Because it is independent of the id, the randomizer can be initialized
outside of "onCreate" method. This is less error-prone.
