### PR TITLE
Add custom serialization for samoa events when using S4

### DIFF
--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/AttributeContentEvent.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/AttributeContentEvent.java
@@ -33,13 +33,8 @@ import com.yahoo.labs.samoa.core.ContentEvent;
  * @author Arinto Murdopo
  *
  */
-final class AttributeContentEvent implements ContentEvent {
+public final class AttributeContentEvent implements ContentEvent {
 
-    static {
-        Kryo kryo = new Kryo();
-        kryo.register(AttributeContentEvent.class, new AttributeCEFullPrecSerializer());
-    }
-    
 	private static final long serialVersionUID = 6652815649846676832L;
 
 	private final long learningNodeId;

--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/ComputeContentEvent.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/ComputeContentEvent.java
@@ -31,13 +31,8 @@ import com.esotericsoftware.kryo.io.Output;
  * @author Arinto Murdopo
  *
  */
-final class ComputeContentEvent extends ControlContentEvent {
+public final class ComputeContentEvent extends ControlContentEvent {
     
-    static {
-        Kryo kryo = new Kryo();
-        kryo.register(ComputeContentEvent.class, new ComputeCEFullPrecSerializer());
-    }
-
 	private static final long serialVersionUID = 5590798490073395190L;
 	
 	private final double[] preSplitDist;

--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/LocalResultContentEvent.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/LocalResultContentEvent.java
@@ -33,11 +33,6 @@ import com.yahoo.labs.samoa.core.ContentEvent;
  */
 final class LocalResultContentEvent implements ContentEvent{
     
-    static {
-        Kryo kryo = new Kryo();
-        kryo.register(LocalResultContentEvent.class);
-    }
-
 	private static final long serialVersionUID = -4206620993777418571L;
 	
 	private final AttributeSplitSuggestion bestSuggestion;

--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/moa/classifiers/core/AttributeSplitSuggestion.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/moa/classifiers/core/AttributeSplitSuggestion.java
@@ -33,11 +33,6 @@ import com.yahoo.labs.samoa.moa.AbstractMOAObject;
 public class AttributeSplitSuggestion extends AbstractMOAObject implements
         Comparable<AttributeSplitSuggestion> {
     
-    static {
-        Kryo kryo = new Kryo();
-        kryo.register(AttributeSplitSuggestion.class);
-    }
-
     private static final long serialVersionUID = 1L;
 
     public InstanceConditionalTest splitTest;

--- a/samoa-s4/src/main/java/com/yahoo/labs/samoa/topology/impl/S4Submitter.java
+++ b/samoa-s4/src/main/java/com/yahoo/labs/samoa/topology/impl/S4Submitter.java
@@ -80,7 +80,7 @@ public class S4Submitter implements ISubmitter {
 				"-appClass=" + S4DoTask.class.getName(),
 				"-appName=" + "samoaApp",
 				"-p=evalTask=" + task.getClass().getSimpleName(),
-				"-zk=localhost:2181", "-s4r=" + appURIString };
+				"-zk=localhost:2181", "-s4r=" + appURIString , "-emc=" + SamoaSerializerModule.class.getName()};
 		// "-emc=" + S4MOAModule.class.getName(),
 		// "@" +
 		// Resources.getResource("s4moa.properties").getFile(),

--- a/samoa-s4/src/main/java/com/yahoo/labs/samoa/topology/impl/SamoaSerializer.java
+++ b/samoa-s4/src/main/java/com/yahoo/labs/samoa/topology/impl/SamoaSerializer.java
@@ -1,0 +1,99 @@
+package com.yahoo.labs.samoa.topology.impl;
+
+/*
+ * #%L
+ * SAMOA
+ * %%
+ * Copyright (C) 2013 - 2014 Yahoo! Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.nio.ByteBuffer;
+
+import org.apache.s4.base.SerializerDeserializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+import com.yahoo.labs.samoa.learners.classifiers.trees.AttributeContentEvent;
+import com.yahoo.labs.samoa.learners.classifiers.trees.ComputeContentEvent;
+
+public class SamoaSerializer implements SerializerDeserializer{
+
+	private ThreadLocal<Kryo> kryoThreadLocal;
+    private ThreadLocal<Output> outputThreadLocal;
+
+    private int initialBufferSize = 2048;
+    private int maxBufferSize = 256 * 1024;
+
+    public void setMaxBufferSize(int maxBufferSize) {
+        this.maxBufferSize = maxBufferSize;
+    }
+
+    /**
+     * 
+     * @param classLoader
+     *            classloader able to handle classes to serialize/deserialize. For instance, application-level events
+     *            can only be handled by the application classloader.
+     */
+    @Inject
+    public SamoaSerializer(@Assisted final ClassLoader classLoader) {
+        kryoThreadLocal = new ThreadLocal<Kryo>() {
+
+            @Override
+            protected Kryo initialValue() {
+                Kryo kryo = new Kryo();
+                kryo.setClassLoader(classLoader);
+                kryo.register(AttributeContentEvent.class, new AttributeContentEvent.AttributeCEFullPrecSerializer());
+                kryo.register(ComputeContentEvent.class, new ComputeContentEvent.ComputeCEFullPrecSerializer());
+                kryo.setRegistrationRequired(false);
+                return kryo;
+            }
+        };
+
+        outputThreadLocal = new ThreadLocal<Output>() {
+            @Override
+            protected Output initialValue() {
+                Output output = new Output(initialBufferSize, maxBufferSize);
+                return output;
+            }
+        };
+
+    }
+
+    @Override
+    public Object deserialize(ByteBuffer rawMessage) {
+        Input input = new Input(rawMessage.array());
+        try {
+            return kryoThreadLocal.get().readClassAndObject(input);
+        } finally {
+            input.close();
+        }
+    }
+
+    @SuppressWarnings("resource")
+    @Override
+    public ByteBuffer serialize(Object message) {
+        Output output = outputThreadLocal.get();
+        try {
+            kryoThreadLocal.get().writeClassAndObject(output, message);
+            return ByteBuffer.wrap(output.toBytes());
+        } finally {
+            output.clear();
+        }
+    }
+}

--- a/samoa-s4/src/main/java/com/yahoo/labs/samoa/topology/impl/SamoaSerializerModule.java
+++ b/samoa-s4/src/main/java/com/yahoo/labs/samoa/topology/impl/SamoaSerializerModule.java
@@ -1,0 +1,35 @@
+package com.yahoo.labs.samoa.topology.impl;
+
+/*
+ * #%L
+ * SAMOA
+ * %%
+ * Copyright (C) 2013 - 2014 Yahoo! Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.apache.s4.base.SerializerDeserializer;
+
+import com.google.inject.AbstractModule;
+
+public class SamoaSerializerModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		bind(SerializerDeserializer.class).to(SamoaSerializer.class);
+		
+	}
+
+}


### PR DESCRIPTION
- pass a custom module defining a custom serializer, that registers samoa event classes and serializers
- could be made configurable by passing a configuration file for events/serializers mapping, and registering using reflection
