### PR TITLE
Consider last instance in filter and aggregator

### DIFF
--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/FilterProcessor.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/FilterProcessor.java
@@ -78,7 +78,7 @@ final class FilterProcessor implements Processor {
                 InstanceContentEvent instanceContentEvent = (InstanceContentEvent) event;
                 this.contentEventList.add(instanceContentEvent);
                 this.waitingInstances++;
-                if (this.waitingInstances == this.batchSize){ 
+                if (this.waitingInstances == this.batchSize || instanceContentEvent.isLastEvent()){
                     //Send Instances
                     InstancesContentEvent outputEvent = new InstancesContentEvent(instanceContentEvent);
                     boolean isLastEvent = false;

--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
@@ -295,6 +295,13 @@ final class ModelAggregatorProcessor implements Processor {
             if (this.numBatches == 1 || this.numBatches > 4){
                 this.processInstances(this.contentEventList.remove(0));
             }
+
+            if (instContentEvent.isLastEvent()) {
+                // drain remaining instances
+                while (!contentEventList.isEmpty()) {
+                    processInstances(contentEventList.remove(0));
+                }
+            }
                 
         }
         


### PR DESCRIPTION
This fixes an issue when running the VHT classifier with prequential evaluation, where
by ignoring the last instance property in filter/aggregator, the topology exited before
evaluating all instances.

Can be tested with:
`bin/samoa local target/SAMOA-Local-0.3.0-SNAPSHOT.jar "PrequentialEvaluation -d /tmp/dump.csv -i 1000000 -f 100000 -l (com.yahoo.labs.samoa.learners.classifiers.trees.VerticalHoeffdingTree -p 4) -s (com.yahoo.labs.samoa.moa.streams.generators.RandomTreeGenerator -c 2 -o 10 -u 10)"`
