### PR TITLE
Improving performance of Naive Bayes using a prototype for zero valued features

### DIFF
--- a/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/NaiveBayes.java
+++ b/samoa-api/src/main/java/com/yahoo/labs/samoa/learners/classifiers/NaiveBayes.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.yahoo.labs.samoa.instances.Attribute;
 import com.yahoo.labs.samoa.instances.Instance;
 import com.yahoo.labs.samoa.instances.Instances;
 import com.yahoo.labs.samoa.moa.classifiers.core.attributeclassobservers.GaussianNumericAttributeClassObserver;
@@ -41,7 +40,10 @@ import com.yahoo.labs.samoa.moa.core.GaussianEstimator;
  * @author Olivier Van Laere (vanlaere yahoo-inc dot com)
  */
 public class NaiveBayes implements LocalLearner {
-
+	
+	/**
+	 * Default smoothing factor. For now fixed to 1E-20.
+	 */
 	private double additive_smoothing_factor = 1e-20;
 	
 	/**


### PR DESCRIPTION
In the current version of the Naive Bayes classifier, we iterate over each attribute, even though this might be very sparse. This is very inefficient.

To cope with this, we implement the following computation (already down to this specific computation)
![nb_prototype](https://cloud.githubusercontent.com/assets/2300860/4955260/fd23ffc2-6693-11e4-81e4-be9f92e71933.png)

This pull request at the same time fixes a nullpointer using NB and prequential evaluation, where there was no classmass assigned yet, while it was being requested by the prequential phase. The classmass is no longer used and thus the bug fixed.
